### PR TITLE
Fix musl build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,17 @@
-FROM rust@sha256:f91b3dae52c0d99302366331e36cf6af8a923d36c68577df1f4d5a7c2721ca90 as build
+FROM rust:1.54-buster@sha256:f91b3dae52c0d99302366331e36cf6af8a923d36c68577df1f4d5a7c2721ca90 as build
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && \
-    apt-get -y install \
+
+RUN apt update && \
+    apt -y install \
     ca-certificates \
     libssl-dev \
-    musl-tools
+    musl-tools \
+    musl-dev
 
 RUN rustup target add x86_64-unknown-linux-musl
+
+RUN update-ca-certificates
 
 WORKDIR /usr/src/rfd-notify
 
@@ -16,17 +20,19 @@ COPY src src
 
 ENV PKG_CONFIG_ALLOW_CROSS=1
 
-RUN RUSTFLAGS=-Clinker=musl-gcc cargo build --release --target=x86_64-unknown-linux-musl
+RUN cargo build --target=x86_64-unknown-linux-musl --release
 
 RUN mkdir /examples
+
 COPY examples /examples
 
+### Final lightweight image
 FROM scratch
 
 COPY --from=build /examples /examples
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=build /usr/src/rfd-notify/target/x86_64-unknown-linux-musl/release/rfd-notify .
+COPY --from=build /usr/src/rfd-notify/target/x86_64-unknown-linux-musl/release/rfd-notify ./rfd-notify
 
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 ENV SSL_CERT_DIR=/etc/ssl/certs


### PR DESCRIPTION
Followed this guide: https://kerkour.com/blog/rust-small-docker-image/

I believe the issue was that `musl-dev` was missing.